### PR TITLE
Add n/a option for items. Closes #8

### DIFF
--- a/src/presets/default.json
+++ b/src/presets/default.json
@@ -15,6 +15,10 @@
     {
       "title": "Possible concern but agreed acceptable",
       "value": ":heavy_exclamation_mark:"
+    },
+    {
+      "title": "Not applicable",
+      "value": ":heavy_minus_sign:"
     }
   ],
   "questionSets": [


### PR DESCRIPTION
@matthojo I went for :heavy_minus_sign:, I struggled to find something else
that could really mean n/a. I used http://www.emoji-cheat-sheet.com/ as my source
for emoji github supports.